### PR TITLE
Fix version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
           
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
GitHub rulesets preventing version bump from running correctly, this update should resolve it.