### PR TITLE
feat: add user configuration system with VS Code Settings integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **User Configuration System** - Customizable extension settings via VS Code Settings UI
+  - `powerPlatformDevSuite.pluginTrace.defaultLimit` - Configure default number of plugin traces to fetch (1-5000, default: 100)
+  - Settings accessible via Command Palette: "Power Platform Developer Suite: Open Settings"
+  - Settings entry in Tools sidebar for quick access
+  - Clean Architecture implementation: `IConfigurationService` interface in domain, `VsCodeConfigurationService` in infrastructure
+  - `NullConfigurationService` test stub for unit testing
+
 ## [0.2.2] - 2025-11-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "power-platform-developer-suite",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "power-platform-developer-suite",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dependencies": {
                 "@azure/msal-node": "^3.8.3"
             },
@@ -253,7 +253,6 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -849,6 +848,7 @@
             "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
@@ -864,6 +864,7 @@
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -875,6 +876,7 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -888,6 +890,7 @@
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.17.0"
             },
@@ -901,6 +904,7 @@
             "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -914,6 +918,7 @@
             "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -938,6 +943,7 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -954,7 +960,8 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0"
+            "license": "Python-2.0",
+            "peer": true
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -962,6 +969,7 @@
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -973,6 +981,7 @@
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -983,6 +992,7 @@
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -995,7 +1005,8 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
             "version": "3.1.2",
@@ -1003,6 +1014,7 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1029,6 +1041,7 @@
             "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -1039,6 +1052,7 @@
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.17.0",
                 "levn": "^0.4.1"
@@ -1053,6 +1067,7 @@
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -1063,6 +1078,7 @@
             "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.4.0"
@@ -1077,6 +1093,7 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -1091,6 +1108,7 @@
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -2436,7 +2454,6 @@
             "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.48.0",
                 "@typescript-eslint/types": "8.48.0",
@@ -3615,7 +3632,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3642,6 +3658,7 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3662,7 +3679,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -4196,7 +4212,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.25",
                 "caniuse-lite": "^1.0.30001754",
@@ -4878,7 +4893,8 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -5593,6 +5609,7 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5824,6 +5841,7 @@
             "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -5854,6 +5872,7 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5871,6 +5890,7 @@
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5882,6 +5902,7 @@
             "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -5895,6 +5916,7 @@
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -5904,7 +5926,8 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "3.1.2",
@@ -5912,6 +5935,7 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5925,6 +5949,7 @@
             "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
@@ -5943,6 +5968,7 @@
             "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -5970,6 +5996,7 @@
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -6146,7 +6173,8 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-uri": {
             "version": "3.1.0",
@@ -6211,6 +6239,7 @@
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -6288,6 +6317,7 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6315,6 +6345,7 @@
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -6328,7 +6359,8 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/for-each": {
             "version": "0.3.5",
@@ -6648,6 +6680,7 @@
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -6684,6 +6717,7 @@
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -7049,6 +7083,7 @@
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -7848,7 +7883,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -8597,7 +8631,8 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -8618,7 +8653,8 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -8768,6 +8804,7 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -8798,6 +8835,7 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8853,6 +8891,7 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -8918,7 +8957,8 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
@@ -9679,6 +9719,7 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9778,6 +9819,7 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -9831,6 +9873,7 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -10210,7 +10253,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -10302,6 +10344,7 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -10375,6 +10418,7 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10783,6 +10827,7 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -12121,7 +12166,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12391,6 +12435,7 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -12549,7 +12594,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -12741,6 +12785,7 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -12857,7 +12902,6 @@
             "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -12907,7 +12951,6 @@
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",
@@ -13135,6 +13178,7 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
     "contributes": {
         "commands": [
             {
+                "command": "power-platform-dev-suite.openSettings",
+                "title": "Open Settings",
+                "category": "Power Platform Developer Suite",
+                "icon": "$(gear)"
+            },
+            {
                 "command": "power-platform-dev-suite.addEnvironment",
                 "title": "Add Environment",
                 "category": "Power Platform Developer Suite",
@@ -329,6 +335,18 @@
                     "group": "1_environment@1"
                 }
             ]
+        },
+        "configuration": {
+            "title": "Power Platform Developer Suite",
+            "properties": {
+                "powerPlatformDevSuite.pluginTrace.defaultLimit": {
+                    "type": "number",
+                    "default": 100,
+                    "minimum": 1,
+                    "maximum": 5000,
+                    "description": "Default number of plugin traces to fetch (1-5000). Increase for powerful environments, decrease for slower connections."
+                }
+            }
         }
     },
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,6 +229,10 @@ export function activate(context: vscode.ExtensionContext): void {
 		environmentsProvider.refresh();
 	});
 
+	const openSettingsCommand = vscode.commands.registerCommand('power-platform-dev-suite.openSettings', () => {
+		vscode.commands.executeCommand('workbench.action.openSettings', 'powerPlatformDevSuite');
+	});
+
 	// Subscribe to domain events
 	container.eventPublisher.subscribe(EnvironmentCreated, () => environmentsProvider.refresh());
 	container.eventPublisher.subscribe(EnvironmentUpdated, () => environmentsProvider.refresh());
@@ -345,7 +349,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	const pluginTraceViewerCommand = vscode.commands.registerCommand('power-platform-dev-suite.pluginTraceViewer', async (environmentItem?: { envId: string }) => {
 		try {
-			void initializePluginTraceViewer(context, factories.getEnvironments, factories.getEnvironmentById, factories.dataverseApiServiceFactory, container.logger, environmentItem?.envId);
+			void initializePluginTraceViewer(context, factories.getEnvironments, factories.getEnvironmentById, factories.dataverseApiServiceFactory, container.logger, container.configService, environmentItem?.envId);
 		} catch (error) {
 			container.logger.error('Failed to open Plugin Trace Viewer', error);
 			vscode.window.showErrorMessage(
@@ -359,7 +363,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			await showEnvironmentPickerAndExecute(
 				container.environmentRepository,
 				'Select an environment to view Plugin Traces',
-				async (envId) => initializePluginTraceViewer(context, factories.getEnvironments, factories.getEnvironmentById, factories.dataverseApiServiceFactory, container.logger, envId)
+				async (envId) => initializePluginTraceViewer(context, factories.getEnvironments, factories.getEnvironmentById, factories.dataverseApiServiceFactory, container.logger, container.configService, envId)
 			);
 		} catch (error) {
 			container.logger.error('Failed to open Plugin Trace Viewer with environment picker', error);
@@ -451,6 +455,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		openMakerCommand,
 		openDynamicsCommand,
 		refreshEnvironmentsCommand,
+		openSettingsCommand,
 		container.eventPublisher
 	);
 

--- a/src/features/environmentSetup/presentation/panels/EnvironmentSetupPanelComposed.ts
+++ b/src/features/environmentSetup/presentation/panels/EnvironmentSetupPanelComposed.ts
@@ -176,6 +176,7 @@ export class EnvironmentSetupPanelComposed {
 
 	private createCoordinator(): { coordinator: PanelCoordinator<EnvironmentSetupCommands>; scaffoldingBehavior: HtmlScaffoldingBehavior } {
 		const formSection = new EnvironmentFormSection();
+
 		// customHandler: true prevents messaging.js from attaching generic click handlers,
 		// since EnvironmentSetupBehavior.js attaches its own handlers that validate and collect form data
 		const actionButtons = new ActionButtonsSection({

--- a/src/features/pluginTraceViewer/domain/entities/TraceFilter.ts
+++ b/src/features/pluginTraceViewer/domain/entities/TraceFilter.ts
@@ -1,3 +1,4 @@
+import { IConfigurationService } from '../../../../shared/domain/services/IConfigurationService';
 import { ValidationError } from '../../../../shared/domain/errors/ValidationError';
 import { ODataQueryBuilder } from '../services/ODataQueryBuilder';
 import { CorrelationId } from '../valueObjects/CorrelationId';
@@ -172,34 +173,54 @@ export class TraceFilter {
 	}
 
 	/**
-	 * Factory method: Create default filter (no criteria)
+	 * Default limit when no configuration is provided.
+	 * Matches VS Code setting default in package.json.
 	 */
-	static default(): TraceFilter {
-		return new TraceFilter(100, 'createdon desc');
+	private static readonly DEFAULT_LIMIT = 100;
+
+	/**
+	 * Factory method: Create default filter (no criteria).
+	 *
+	 * @param configService - Optional configuration service for reading user settings
+	 * @returns TraceFilter with default top limit from config or hardcoded fallback
+	 */
+	static default(configService?: IConfigurationService): TraceFilter {
+		const defaultLimit = configService?.get('pluginTrace.defaultLimit', TraceFilter.DEFAULT_LIMIT)
+			?? TraceFilter.DEFAULT_LIMIT;
+		return new TraceFilter(defaultLimit, 'createdon desc');
 	}
 
 	/**
-	 * Factory method: Create filter from parameters
+	 * Factory method: Create filter from parameters.
+	 *
+	 * @param params - Filter parameters
+	 * @param configService - Optional configuration service for reading default top limit
 	 */
-	static create(params: {
-		top?: number;
-		orderBy?: string;
-		conditions?: readonly FilterCondition[];
-		pluginNameFilter?: string;
-		entityNameFilter?: string;
-		messageNameFilter?: string;
-		operationTypeFilter?: OperationType;
-		modeFilter?: ExecutionMode;
-		statusFilter?: TraceStatus;
-		createdOnFrom?: Date;
-		createdOnTo?: Date;
-		durationMin?: number;
-		durationMax?: number;
-		hasExceptionFilter?: boolean;
-		correlationIdFilter?: CorrelationId;
-	}): TraceFilter {
+	static create(
+		params: {
+			top?: number;
+			orderBy?: string;
+			conditions?: readonly FilterCondition[];
+			pluginNameFilter?: string;
+			entityNameFilter?: string;
+			messageNameFilter?: string;
+			operationTypeFilter?: OperationType;
+			modeFilter?: ExecutionMode;
+			statusFilter?: TraceStatus;
+			createdOnFrom?: Date;
+			createdOnTo?: Date;
+			durationMin?: number;
+			durationMax?: number;
+			hasExceptionFilter?: boolean;
+			correlationIdFilter?: CorrelationId;
+		},
+		configService?: IConfigurationService
+	): TraceFilter {
+		const defaultLimit = configService?.get('pluginTrace.defaultLimit', TraceFilter.DEFAULT_LIMIT)
+			?? TraceFilter.DEFAULT_LIMIT;
+
 		return new TraceFilter(
-			params.top ?? 100,
+			params.top ?? defaultLimit,
 			params.orderBy ?? 'createdon desc',
 			params.conditions ?? [],
 			params.pluginNameFilter,

--- a/src/features/pluginTraceViewer/domain/entities/TraceFilter.ts
+++ b/src/features/pluginTraceViewer/domain/entities/TraceFilter.ts
@@ -178,6 +178,9 @@ export class TraceFilter {
 	 */
 	private static readonly DEFAULT_LIMIT = 100;
 
+	/** Configuration key for the default trace limit setting. */
+	private static readonly CONFIG_KEY_DEFAULT_LIMIT = 'pluginTrace.defaultLimit';
+
 	/**
 	 * Factory method: Create default filter (no criteria).
 	 *
@@ -185,7 +188,7 @@ export class TraceFilter {
 	 * @returns TraceFilter with default top limit from config or hardcoded fallback
 	 */
 	static default(configService?: IConfigurationService): TraceFilter {
-		const defaultLimit = configService?.get('pluginTrace.defaultLimit', TraceFilter.DEFAULT_LIMIT)
+		const defaultLimit = configService?.get(TraceFilter.CONFIG_KEY_DEFAULT_LIMIT, TraceFilter.DEFAULT_LIMIT)
 			?? TraceFilter.DEFAULT_LIMIT;
 		return new TraceFilter(defaultLimit, 'createdon desc');
 	}
@@ -216,7 +219,7 @@ export class TraceFilter {
 		},
 		configService?: IConfigurationService
 	): TraceFilter {
-		const defaultLimit = configService?.get('pluginTrace.defaultLimit', TraceFilter.DEFAULT_LIMIT)
+		const defaultLimit = configService?.get(TraceFilter.CONFIG_KEY_DEFAULT_LIMIT, TraceFilter.DEFAULT_LIMIT)
 			?? TraceFilter.DEFAULT_LIMIT;
 
 		return new TraceFilter(

--- a/src/features/pluginTraceViewer/presentation/behaviors/PluginTraceFilterManagementBehavior.test.ts
+++ b/src/features/pluginTraceViewer/presentation/behaviors/PluginTraceFilterManagementBehavior.test.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 import { PluginTraceFilterManagementBehavior } from './PluginTraceFilterManagementBehavior';
 import type { ILogger } from '../../../../infrastructure/logging/ILogger';
 import type { IPanelStateRepository } from '../../../../shared/infrastructure/ui/IPanelStateRepository';
-import { FilterCriteriaMapper } from '../mappers/FilterCriteriaMapper';
 import type { FilterCriteriaViewModel } from '../../application/viewModels/FilterCriteriaViewModel';
 import { NullLogger } from '../../../../infrastructure/logging/NullLogger';
 import { assertDefined } from '../../../../shared/testing';
@@ -53,7 +52,7 @@ describe('PluginTraceFilterManagementBehavior', () => {
 		it('should initialize with empty filter criteria', () => {
 			const criteria = behavior.getFilterCriteria();
 
-			expect(criteria).toEqual(FilterCriteriaMapper.empty());
+			expect(criteria).toEqual({ conditions: [], top: 100 });
 		});
 
 		it('should initialize with empty reconstructed quick filter IDs', () => {
@@ -229,7 +228,7 @@ describe('PluginTraceFilterManagementBehavior', () => {
 			await behavior.clearFilters();
 
 			const criteria = behavior.getFilterCriteria();
-			expect(criteria).toEqual(FilterCriteriaMapper.empty());
+			expect(criteria).toEqual({ conditions: [], top: 100 });
 		});
 
 		it('should persist empty filter criteria', async () => {
@@ -460,7 +459,7 @@ describe('PluginTraceFilterManagementBehavior', () => {
 			await behavior.loadFilterCriteria(TEST_ENVIRONMENT_ID);
 
 			const criteria = behavior.getFilterCriteria();
-			expect(criteria).toEqual(FilterCriteriaMapper.empty());
+			expect(criteria).toEqual({ conditions: [], top: 100 });
 		});
 
 		it('should handle null repository gracefully', async () => {
@@ -476,7 +475,7 @@ describe('PluginTraceFilterManagementBehavior', () => {
 			await behaviorWithoutRepo.loadFilterCriteria(TEST_ENVIRONMENT_ID);
 
 			const criteria = behaviorWithoutRepo.getFilterCriteria();
-			expect(criteria).toEqual(FilterCriteriaMapper.empty());
+			expect(criteria).toEqual({ conditions: [], top: 100 });
 		});
 
 		it('should handle invalid stored data gracefully', async () => {
@@ -488,7 +487,7 @@ describe('PluginTraceFilterManagementBehavior', () => {
 
 			// Should not throw, should handle gracefully
 			const criteria = behavior.getFilterCriteria();
-			expect(criteria).toEqual(FilterCriteriaMapper.empty());
+			expect(criteria).toEqual({ conditions: [], top: 100 });
 		});
 	});
 

--- a/src/features/pluginTraceViewer/presentation/behaviors/PluginTraceFilterManagementBehavior.ts
+++ b/src/features/pluginTraceViewer/presentation/behaviors/PluginTraceFilterManagementBehavior.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import type { ILogger } from '../../../../infrastructure/logging/ILogger';
+import type { IConfigurationService } from '../../../../shared/domain/services/IConfigurationService';
 import type { IPanelStateRepository, PanelState } from '../../../../shared/infrastructure/ui/IPanelStateRepository';
 import { FilterCriteriaMapper } from '../mappers/FilterCriteriaMapper';
 import type { FilterCriteriaViewModel, FilterConditionViewModel } from '../../application/viewModels/FilterCriteriaViewModel';
@@ -36,10 +37,11 @@ export class PluginTraceFilterManagementBehavior {
 		private readonly panelStateRepository: IPanelStateRepository | null,
 		private readonly viewType: string,
 		private readonly onRefreshNeeded: () => Promise<void>,
-		private readonly onPersistState: () => Promise<void>
+		private readonly onPersistState: () => Promise<void>,
+		configService?: IConfigurationService
 	) {
-		this.filterCriteriaMapper = new FilterCriteriaMapper();
-		this.filterCriteria = FilterCriteriaMapper.empty();
+		this.filterCriteriaMapper = new FilterCriteriaMapper(configService);
+		this.filterCriteria = this.filterCriteriaMapper.empty();
 	}
 
 	/**
@@ -143,7 +145,7 @@ export class PluginTraceFilterManagementBehavior {
 			this.logger.debug('Clearing filters');
 
 			// Reset to empty filter criteria and clear active quick filters
-			this.filterCriteria = FilterCriteriaMapper.empty();
+			this.filterCriteria = this.filterCriteriaMapper.empty();
 			this.activeQuickFilterIds = [];
 
 			// Persist empty filter criteria

--- a/src/features/pluginTraceViewer/presentation/initialization/initializePluginTraceViewer.ts
+++ b/src/features/pluginTraceViewer/presentation/initialization/initializePluginTraceViewer.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import type { ILogger } from '../../../../infrastructure/logging/ILogger';
+import type { IConfigurationService } from '../../../../shared/domain/services/IConfigurationService';
 
 /**
  * Lazy-loads and initializes Plugin Trace Viewer panel.
@@ -12,6 +13,7 @@ export async function initializePluginTraceViewer(
 	getEnvironmentById: (envId: string) => Promise<{ id: string; name: string; powerPlatformEnvironmentId: string | undefined } | null>,
 	dataverseApiServiceFactory: { getAccessToken: (envId: string) => Promise<string>; getDataverseUrl: (envId: string) => Promise<string> },
 	logger: ILogger,
+	configService: IConfigurationService,
 	initialEnvironmentId?: string
 ): Promise<void> {
 	const { DataverseApiService } = await import('../../../../shared/infrastructure/services/DataverseApiService.js');
@@ -32,7 +34,7 @@ export async function initializePluginTraceViewer(
 	const pluginTraceRepository = new DataversePluginTraceRepository(dataverseApiService, logger);
 	const pluginTraceExporter = new FileSystemPluginTraceExporter(logger);
 
-	const getPluginTracesUseCase = new GetPluginTracesUseCase(pluginTraceRepository, logger);
+	const getPluginTracesUseCase = new GetPluginTracesUseCase(pluginTraceRepository, logger, configService);
 	const deleteTracesUseCase = new DeleteTracesUseCase(pluginTraceRepository, logger);
 	const exportTracesUseCase = new ExportTracesUseCase(pluginTraceExporter, logger);
 	const getTraceLevelUseCase = new GetTraceLevelUseCase(pluginTraceRepository, logger);

--- a/src/features/pluginTraceViewer/presentation/initialization/initializePluginTraceViewer.ts
+++ b/src/features/pluginTraceViewer/presentation/initialization/initializePluginTraceViewer.ts
@@ -60,6 +60,7 @@ export async function initializePluginTraceViewer(
 		viewModelMapper,
 		logger,
 		initialEnvironmentId,
-		panelStateRepository
+		panelStateRepository,
+		configService
 	);
 }

--- a/src/features/pluginTraceViewer/presentation/mappers/FilterCriteriaMapper.test.ts
+++ b/src/features/pluginTraceViewer/presentation/mappers/FilterCriteriaMapper.test.ts
@@ -436,16 +436,30 @@ describe('FilterCriteriaMapper', () => {
 	});
 
 	describe('empty', () => {
-		it('should create empty FilterCriteriaViewModel', () => {
-			const result = FilterCriteriaMapper.empty();
+		it('should create empty FilterCriteriaViewModel with default top', () => {
+			const mapper = new FilterCriteriaMapper();
+			const result = mapper.empty();
 
 			expect(result.conditions).toEqual([]);
 			expect(result.top).toBe(100);
 		});
 
+		it('should use configured default limit when config service provided', () => {
+			const mockConfigService = {
+				get: jest.fn().mockReturnValue(250)
+			};
+			const mapper = new FilterCriteriaMapper(mockConfigService);
+			const result = mapper.empty();
+
+			expect(result.conditions).toEqual([]);
+			expect(result.top).toBe(250);
+			expect(mockConfigService.get).toHaveBeenCalledWith('pluginTrace.defaultLimit', 100);
+		});
+
 		it('should return new instance each time', () => {
-			const result1 = FilterCriteriaMapper.empty();
-			const result2 = FilterCriteriaMapper.empty();
+			const mapper = new FilterCriteriaMapper();
+			const result1 = mapper.empty();
+			const result2 = mapper.empty();
 
 			expect(result1).not.toBe(result2);
 			expect(result1.conditions).not.toBe(result2.conditions);

--- a/src/features/pluginTraceViewer/presentation/mappers/FilterCriteriaMapper.ts
+++ b/src/features/pluginTraceViewer/presentation/mappers/FilterCriteriaMapper.ts
@@ -1,3 +1,4 @@
+import type { IConfigurationService } from '../../../../shared/domain/services/IConfigurationService';
 import {
 	TraceFilter,
 	FilterCondition,
@@ -16,6 +17,10 @@ import type {
  * Handles type conversions and validation.
  */
 export class FilterCriteriaMapper {
+	constructor(
+		private readonly configService?: IConfigurationService
+	) {}
+
 	/**
 	 * Maps ViewModel (query builder form) to domain TraceFilter entity.
 	 */
@@ -28,7 +33,7 @@ export class FilterCriteriaMapper {
 		return TraceFilter.create({
 			top: viewModel.top,
 			conditions
-		});
+		}, this.configService);
 	}
 
 	/**
@@ -92,13 +97,19 @@ export class FilterCriteriaMapper {
 		};
 	}
 
+	/** Default limit when no configuration is provided. */
+	private static readonly DEFAULT_LIMIT = 100;
+
 	/**
 	 * Creates empty filter criteria with no conditions.
+	 * Uses configured default limit if config service is available.
 	 */
-	public static empty(): FilterCriteriaViewModel {
+	public empty(): FilterCriteriaViewModel {
+		const defaultLimit = this.configService?.get('pluginTrace.defaultLimit', FilterCriteriaMapper.DEFAULT_LIMIT)
+			?? FilterCriteriaMapper.DEFAULT_LIMIT;
 		return {
 			conditions: [],
-			top: 100
+			top: defaultLimit
 		};
 	}
 

--- a/src/infrastructure/configuration/NullConfigurationService.test.ts
+++ b/src/infrastructure/configuration/NullConfigurationService.test.ts
@@ -1,0 +1,61 @@
+import { NullConfigurationService } from './NullConfigurationService';
+
+describe('NullConfigurationService', () => {
+	let configService: NullConfigurationService;
+
+	beforeEach(() => {
+		configService = new NullConfigurationService();
+	});
+
+	describe('get', () => {
+		it('should return default value for any key', () => {
+			const result = configService.get('any.key', 42);
+
+			expect(result).toBe(42);
+		});
+
+		it('should return string default value', () => {
+			const result = configService.get('string.key', 'default');
+
+			expect(result).toBe('default');
+		});
+
+		it('should return number default value', () => {
+			const result = configService.get('number.key', 100);
+
+			expect(result).toBe(100);
+		});
+
+		it('should return boolean default value', () => {
+			const result = configService.get('boolean.key', true);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return object default value', () => {
+			const defaultObj = { foo: 'bar' };
+
+			const result = configService.get('object.key', defaultObj);
+
+			expect(result).toBe(defaultObj);
+		});
+
+		it('should return array default value', () => {
+			const defaultArr = [1, 2, 3];
+
+			const result = configService.get('array.key', defaultArr);
+
+			expect(result).toBe(defaultArr);
+		});
+
+		it('should ignore key parameter', () => {
+			const result1 = configService.get('pluginTrace.defaultLimit', 100);
+			const result2 = configService.get('table.defaultPageSize', 100);
+			const result3 = configService.get('nonexistent.key', 100);
+
+			expect(result1).toBe(100);
+			expect(result2).toBe(100);
+			expect(result3).toBe(100);
+		});
+	});
+});

--- a/src/infrastructure/configuration/NullConfigurationService.ts
+++ b/src/infrastructure/configuration/NullConfigurationService.ts
@@ -1,0 +1,26 @@
+import { IConfigurationService } from '../../shared/domain/services/IConfigurationService';
+
+/**
+ * Null implementation of configuration service for testing.
+ *
+ * Always returns the provided default value, ignoring the key.
+ * Use in unit tests to avoid VS Code API dependencies.
+ *
+ * @example
+ * ```typescript
+ * const config = new NullConfigurationService();
+ * const limit = config.get('pluginTrace.defaultLimit', 100); // Returns 100
+ * ```
+ */
+export class NullConfigurationService implements IConfigurationService {
+	/**
+	 * Returns the default value, ignoring the key.
+	 *
+	 * @param _key - Ignored setting key
+	 * @param defaultValue - Value to return
+	 * @returns The provided default value
+	 */
+	public get<T>(_key: string, defaultValue: T): T {
+		return defaultValue;
+	}
+}

--- a/src/infrastructure/configuration/VsCodeConfigurationService.test.ts
+++ b/src/infrastructure/configuration/VsCodeConfigurationService.test.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode';
+
+import { VsCodeConfigurationService } from './VsCodeConfigurationService';
+
+describe('VsCodeConfigurationService', () => {
+	let service: VsCodeConfigurationService;
+	let mockGet: jest.Mock;
+
+	beforeEach(() => {
+		mockGet = jest.fn();
+		(vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+			get: mockGet
+		});
+		service = new VsCodeConfigurationService();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('get', () => {
+		it('should read configuration with powerPlatformDevSuite namespace', () => {
+			mockGet.mockReturnValue(100);
+
+			service.get('pluginTrace.defaultLimit', 100);
+
+			expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith('powerPlatformDevSuite');
+		});
+
+		it('should pass key and default value to config.get', () => {
+			mockGet.mockReturnValue(250);
+
+			service.get('pluginTrace.defaultLimit', 100);
+
+			expect(mockGet).toHaveBeenCalledWith('pluginTrace.defaultLimit', 100);
+		});
+
+		it('should return configured value when set', () => {
+			mockGet.mockReturnValue(500);
+
+			const result = service.get('pluginTrace.defaultLimit', 100);
+
+			expect(result).toBe(500);
+		});
+
+		it('should return default value when not configured', () => {
+			mockGet.mockImplementation((_key: string, defaultValue: number) => defaultValue);
+
+			const result = service.get('pluginTrace.defaultLimit', 100);
+
+			expect(result).toBe(100);
+		});
+
+		it('should support string configuration values', () => {
+			mockGet.mockReturnValue('custom-value');
+
+			const result = service.get('some.stringKey', 'default');
+
+			expect(result).toBe('custom-value');
+		});
+
+		it('should support boolean configuration values', () => {
+			mockGet.mockReturnValue(true);
+
+			const result = service.get('some.booleanKey', false);
+
+			expect(result).toBe(true);
+		});
+
+		it('should support nested key paths', () => {
+			mockGet.mockReturnValue(42);
+
+			service.get('deeply.nested.key.path', 0);
+
+			expect(mockGet).toHaveBeenCalledWith('deeply.nested.key.path', 0);
+		});
+	});
+});

--- a/src/infrastructure/configuration/VsCodeConfigurationService.ts
+++ b/src/infrastructure/configuration/VsCodeConfigurationService.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+import { IConfigurationService } from '../../shared/domain/services/IConfigurationService';
+
+/**
+ * VS Code implementation of configuration service.
+ *
+ * Reads from VS Code user/workspace settings under 'powerPlatformDevSuite' namespace.
+ * Settings defined in package.json contributes.configuration section.
+ */
+export class VsCodeConfigurationService implements IConfigurationService {
+	/**
+	 * Configuration namespace prefix.
+	 * Settings are accessed as 'powerPlatformDevSuite.{key}' in VS Code settings.
+	 */
+	private static readonly NAMESPACE = 'powerPlatformDevSuite';
+
+	/**
+	 * Gets configuration value from VS Code settings.
+	 * Falls back to default if not configured.
+	 *
+	 * @param key - Dot-notation key relative to namespace (e.g., 'pluginTrace.defaultLimit')
+	 * @param defaultValue - Fallback value if setting not configured
+	 * @returns Configured value or default
+	 */
+	public get<T>(key: string, defaultValue: T): T {
+		const config = vscode.workspace.getConfiguration(VsCodeConfigurationService.NAMESPACE);
+		return config.get<T>(key, defaultValue);
+	}
+}

--- a/src/infrastructure/dependencyInjection/CoreServicesContainer.ts
+++ b/src/infrastructure/dependencyInjection/CoreServicesContainer.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import { IConfigurationService } from '../../shared/domain/services/IConfigurationService';
+import { VsCodeConfigurationService } from '../configuration/VsCodeConfigurationService';
 import { ILogger } from '../logging/ILogger';
 import { OutputChannelLogger } from '../logging/OutputChannelLogger';
 import { IEnvironmentRepository } from '../../features/environmentSetup/domain/interfaces/IEnvironmentRepository';
@@ -18,6 +20,7 @@ import { VsCodeEventPublisher } from '../../features/environmentSetup/infrastruc
  */
 export class CoreServicesContainer {
 	public readonly logger: ILogger;
+	public readonly configService: IConfigurationService;
 	public readonly environmentRepository: IEnvironmentRepository;
 	public readonly authService: MsalAuthenticationService;
 	public readonly whoAmIService: WhoAmIService;
@@ -28,6 +31,9 @@ export class CoreServicesContainer {
 		// Create logger first (no dependencies)
 		const outputChannel = vscode.window.createOutputChannel('Power Platform Developer Suite', { log: true });
 		this.logger = new OutputChannelLogger(outputChannel);
+
+		// Create configuration service (no dependencies)
+		this.configService = new VsCodeConfigurationService();
 
 		// Create environment repository (depends on logger)
 		const environmentDomainMapper = new EnvironmentDomainMapper(this.logger);

--- a/src/infrastructure/dependencyInjection/TreeViewProviders.ts
+++ b/src/infrastructure/dependencyInjection/TreeViewProviders.ts
@@ -27,7 +27,8 @@ export class ToolsTreeProvider implements vscode.TreeDataProvider<ToolItem> {
 			new ToolItem('Environment Variables', 'View environment variables', 'environmentVariables', 'power-platform-dev-suite.environmentVariables', 'symbol-variable'),
 			new ToolItem('Plugin Traces', 'View and manage plugin trace logs', 'pluginTraceViewer', 'power-platform-dev-suite.pluginTraceViewer', 'bug'),
 			new ToolItem('Metadata Browser', 'Browse entity metadata and attributes', 'metadataBrowser', 'power-platform-dev-suite.metadataBrowser', 'database'),
-			new ToolItem('Data Explorer', 'Query data with SQL syntax', 'dataExplorer', 'power-platform-dev-suite.dataExplorer', 'search')
+			new ToolItem('Data Explorer', 'Query data with SQL syntax', 'dataExplorer', 'power-platform-dev-suite.dataExplorer', 'search'),
+			new ToolItem('Settings', 'Configure extension settings', 'settings', 'power-platform-dev-suite.openSettings', 'gear')
 		];
 	}
 }

--- a/src/shared/domain/services/IConfigurationService.ts
+++ b/src/shared/domain/services/IConfigurationService.ts
@@ -14,7 +14,7 @@ export interface IConfigurationService {
 	/**
 	 * Gets configuration value with type-safe default.
 	 *
-	 * @param key - Setting key relative to 'ppds' namespace (e.g., 'pluginTrace.defaultLimit')
+	 * @param key - Setting key relative to 'powerPlatformDevSuite' namespace (e.g., 'pluginTrace.defaultLimit')
 	 * @param defaultValue - Value returned if setting not configured
 	 * @returns Configured value or default
 	 */

--- a/src/shared/domain/services/IConfigurationService.ts
+++ b/src/shared/domain/services/IConfigurationService.ts
@@ -1,0 +1,22 @@
+/**
+ * Configuration service for reading user settings.
+ *
+ * Abstraction over VS Code workspace configuration.
+ * Domain defines contract, infrastructure implements.
+ *
+ * @example
+ * ```typescript
+ * // In use case or panel
+ * const limit = config.get('pluginTrace.defaultLimit', 100);
+ * ```
+ */
+export interface IConfigurationService {
+	/**
+	 * Gets configuration value with type-safe default.
+	 *
+	 * @param key - Setting key relative to 'ppds' namespace (e.g., 'pluginTrace.defaultLimit')
+	 * @param defaultValue - Value returned if setting not configured
+	 * @returns Configured value or default
+	 */
+	get<T>(key: string, defaultValue: T): T;
+}


### PR DESCRIPTION
## Summary

- Add configurable extension settings via VS Code Settings UI
- `powerPlatformDevSuite.pluginTrace.defaultLimit` setting (1-5000, default: 100) controls default trace fetch limit
- Settings accessible via Command Palette ("Open Settings") and Tools sidebar entry
- Clean Architecture: `IConfigurationService` interface in domain, `VsCodeConfigurationService` in infrastructure
- `NullConfigurationService` test stub for unit testing

## Test plan

- [x] F5 test: Settings appear under "Power Platform Developer Suite" in VS Code Settings
- [x] F5 test: Command Palette "Power Platform Developer Suite: Open Settings" works
- [x] F5 test: Tools sidebar "Settings" entry opens settings
- [x] F5 test: Changing `pluginTrace.defaultLimit` affects Plugin Trace Viewer fetch count
- [x] All 243 tests pass (including 7 new VsCodeConfigurationService tests)