### PR TITLE
fix: post-checkout hook symlinks now work on Windows

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -49,7 +49,15 @@ Worktrees will automatically get **symlinks** to the main repo files.
 - Check hook output during `git worktree add`
 
 **Manual symlink creation (if hook fails):**
+
+Windows (Git Bash):
 ```bash
 cd /path/to/worktree
 MSYS=winsymlinks:nativestrict ln -s /path/to/main-repo/.mcp.json .mcp.json
+```
+
+macOS/Linux:
+```bash
+cd /path/to/worktree
+ln -s /path/to/main-repo/.mcp.json .mcp.json
 ```

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -6,6 +6,15 @@
 git config core.hooksPath .githooks
 ```
 
+## Windows Requirements
+
+**Developer Mode must be enabled** for symlinks to work without Administrator privileges:
+
+1. Open **Settings** > **Privacy & Security** > **For developers**
+2. Enable **Developer Mode**
+
+Without Developer Mode, the post-checkout hook will fail to create symlinks.
+
 ## Hooks
 
 ### post-checkout
@@ -31,3 +40,16 @@ Create these files in main repo using the examples as templates:
 | `.env.e2e.local` | `.env.e2e.local.example` |
 
 Worktrees will automatically get **symlinks** to the main repo files.
+
+## Troubleshooting
+
+**Symlinks not created?**
+- Verify Developer Mode is enabled (Windows)
+- Verify source files exist in main repo
+- Check hook output during `git worktree add`
+
+**Manual symlink creation (if hook fails):**
+```bash
+cd /path/to/worktree
+MSYS=winsymlinks:nativestrict ln -s /path/to/main-repo/.mcp.json .mcp.json
+```

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -8,6 +8,10 @@
 # - .env.e2e.local (E2E test credentials)
 #
 # Setup: git config core.hooksPath .githooks
+#
+# Windows Requirements:
+# - Developer Mode must be enabled (Settings > Privacy & Security > For developers)
+# - Without Developer Mode, symlink creation requires Administrator privileges
 
 # Cross-platform symlink creation
 create_symlink() {
@@ -19,18 +23,15 @@ create_symlink() {
         mkdir -p "$(dirname "$target")"
     fi
 
-    if command -v cygpath >/dev/null 2>&1; then
-        # Windows (Git Bash/Cygwin)
-        local WIN_TARGET WIN_SOURCE
-        WIN_TARGET=$(cygpath -w "$(pwd)/$target" 2>/dev/null) || return 0
-        WIN_SOURCE=$(cygpath -w "$source" 2>/dev/null) || return 0
-        cmd //c "mklink \"$WIN_TARGET\" \"$WIN_SOURCE\"" > /dev/null 2>&1
+    # Use MSYS environment variable to create native Windows symlinks
+    # This works in Git Bash hook context where cmd //c mklink fails
+    if MSYS=winsymlinks:nativestrict ln -s "$source" "$target" 2>/dev/null; then
+        echo "  ✓ Linked: $target"
+        return 0
     else
-        # Unix (macOS/Linux)
-        ln -s "$source" "$target" 2>/dev/null
+        echo "  ✗ Failed: $target (enable Developer Mode in Windows Settings)" >&2
+        return 1
     fi
-
-    [ $? -eq 0 ] && echo "✓ Linked: $target"
 }
 
 # Get main repo root (only works in worktrees)
@@ -50,6 +51,7 @@ FILES_TO_LINK=(
     ".env.e2e.local"
 )
 
+echo "Setting up worktree symlinks..."
 for target in "${FILES_TO_LINK[@]}"; do
     source="$MAIN_REPO_ROOT/$target"
     if [ -f "$source" ] && [ ! -e "$target" ]; then

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -23,15 +23,23 @@ create_symlink() {
         mkdir -p "$(dirname "$target")"
     fi
 
-    # Use MSYS environment variable to create native Windows symlinks
-    # This works in Git Bash hook context where cmd //c mklink fails
-    if MSYS=winsymlinks:nativestrict ln -s "$source" "$target" 2>/dev/null; then
-        echo "  ✓ Linked: $target"
-        return 0
+    if command -v cygpath >/dev/null 2>&1; then
+        # Windows (Git Bash/Cygwin)
+        # Use MSYS environment variable to create native Windows symlinks
+        if ! MSYS=winsymlinks:nativestrict ln -s "$source" "$target" 2>/dev/null; then
+            echo "  ✗ Failed: $target (enable Developer Mode in Windows Settings)" >&2
+            return 1
+        fi
     else
-        echo "  ✗ Failed: $target (enable Developer Mode in Windows Settings)" >&2
-        return 1
+        # Unix (macOS/Linux)
+        if ! ln -s "$source" "$target" 2>/dev/null; then
+            echo "  ✗ Failed: $target (check permissions)" >&2
+            return 1
+        fi
     fi
+
+    echo "  ✓ Linked: $target"
+    return 0
 }
 
 # Get main repo root (only works in worktrees)


### PR DESCRIPTION
## Summary
- Fixed post-checkout hook failing to create symlinks in git hook context on Windows
- Root cause: `cmd //c mklink` fails in git hook context due to shell environment differences
- Solution: Use `MSYS=winsymlinks:nativestrict ln -s` for native Windows symlink creation

## Changes
- `.githooks/post-checkout`: Use MSYS environment variable instead of cmd mklink
- `.githooks/README.md`: Added Windows Developer Mode requirement and troubleshooting section

## Test plan
- [x] Create worktree with `git worktree add` - symlinks created automatically
- [x] Verify symlinks point to main repo files
- [x] Tested on all 3 feature worktrees (solution-diff, deployment-settings, plugin-registration)